### PR TITLE
Remove htmLawedTest.php from repository auto-generated ZIP archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 script/ export-ignore
+/htmLawedTest.php export-ignore
 
 # preserve borked eol lf/crlf usage from original packaging
 htmLawed_README.htm -text


### PR DESCRIPTION
What about removing the `htmLawedTest.php` from the auto-generated ZIP archives?

These archives are used in production, people that want this developers-only file can still perform a `git clone`