### PR TITLE
Autoloads HTMLawed functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
     "require": {
         "php": ">=4.4"
     },
+    "autoload": {
+        "files": ["htmLawed.php"]
+    },
     "repositories": [
         {
          "type": "composer",


### PR DESCRIPTION
This PR autoloads the `htmLawed.php` file using Composer. This functionality was existing in this project until version `1.2.9`. It's removal has broken use of this library in frameworks such as Concrete CMS: they expect global access to the `htmLawed` function when including this package in Composer.